### PR TITLE
fix(themes): Resolve location not defined error in dev mode

### DIFF
--- a/hooks/use-set-theme.ts
+++ b/hooks/use-set-theme.ts
@@ -1,35 +1,36 @@
-'use client'
+"use client";
 
-import { ShadcnTheme, useTheme } from "@/components/shadcn-theme-provider";
-import { sanitizeName } from "@/lib/utils";
-import themes from "@/themes/index.json"
-import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import themes from "@/themes/index.json";
+import { sanitizeName } from "@/lib/utils";
+import { ShadcnTheme, useTheme } from "@/components/shadcn-theme-provider";
 
-const themesNames = themes.map((t) => sanitizeName(t.name));
+
+const themesNames = themes.map((t) => sanitizeName(t.name))
 
 const useSetTheme = (theme: string) => {
-    const router = useRouter();
-    const { setCurrentTheme } = useTheme();
-    const pathname = usePathname()
+  const router = useRouter()
+  const { setCurrentTheme } = useTheme()
+  const pathname = usePathname()
 
-    const [, , ...nested] = pathname.split('/');
+  const [, , ...nested] = pathname.split("/")
 
-    const currentPage = nested ? `/${nested.join('/')}` : ''
-  
-    if (!themesNames.includes(theme)) {
-      router.replace(`/${sanitizeName(themes[0].name)}/${currentPage}`);
-    }
-  
-    const currentTheme =
-      themes.find((t) => sanitizeName(t.name) === sanitizeName(theme)) ??
-      themes[0];
-  
-    useEffect(() => {
-      setCurrentTheme(currentTheme as ShadcnTheme);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+  const currentPage = nested ? `/${nested.join("/")}` : ""
 
+  
+  if (typeof window !== "undefined" && !themesNames.includes(theme)) {
+      router.replace(`/${sanitizeName(themes[0].name)}/${currentPage}`)
+  }
+
+  const currentTheme =
+    themes.find((t) => sanitizeName(t.name) === sanitizeName(theme)) ??
+    themes[0]
+
+  useEffect(() => {
+    setCurrentTheme(currentTheme as ShadcnTheme)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 }
 
 export { useSetTheme }


### PR DESCRIPTION
checked if the code is running on the client-side before accessing the window location object. This ensures the location object is only used on the client-side.